### PR TITLE
Cwdfix

### DIFF
--- a/EQEmu Patcher/EQEmu Patcher/MainForm.Designer.cs
+++ b/EQEmu Patcher/EQEmu Patcher/MainForm.Designer.cs
@@ -65,6 +65,7 @@
             // btnStart
             // 
             this.btnStart.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnStart.Enabled = false;
             this.btnStart.Location = new System.Drawing.Point(315, 463);
             this.btnStart.Name = "btnStart";
             this.btnStart.Size = new System.Drawing.Size(95, 52);

--- a/EQEmu Patcher/EQEmu Patcher/MainForm.cs
+++ b/EQEmu Patcher/EQEmu Patcher/MainForm.cs
@@ -135,7 +135,8 @@ namespace EQEmu_Patcher
                 // btnStart.Enabled = false; // this is a cached value
                btnCheck.BackColor = Color.Red;
             } else
-            {                
+            {
+                btnStart.Enabled = true;
                 if ( IniLibrary.instance.AutoPlay.ToLower() == "true") PlayGame();
             }
             chkAutoPlay.Checked = (IniLibrary.instance.AutoPlay == "true");

--- a/EQEmu Patcher/EQEmu Patcher/MainForm.cs
+++ b/EQEmu Patcher/EQEmu Patcher/MainForm.cs
@@ -47,10 +47,26 @@ namespace EQEmu_Patcher
 
         VersionTypes currentVersion;
 
-       // TaskbarItemInfo tii = new TaskbarItemInfo();
+        // TaskbarItemInfo tii = new TaskbarItemInfo();
         public MainForm()
         {
             InitializeComponent();
+
+            Directory.SetCurrentDirectory(Application.StartupPath); // .exe folder instead of system32
+
+            if (!File.Exists("eqgame.exe"))
+            {
+                String message = "Place the patcher in a NEW and EMPTY folder before running.\r\n\r\n";
+                message += "EverQuest files (thousands of them) will be downloaded to the following folder:\r\n\r\n";
+                message += Environment.CurrentDirectory + "\r\n\r\n";
+                message += "Do you wish to proceed?";
+                DialogResult dr = MessageBox.Show(message, "VZTZ Fresh Install (eqgame.exe not found)", MessageBoxButtons.YesNo);
+
+                if (dr != DialogResult.Yes)
+                {
+                    Environment.Exit(0);
+                }
+            }
         }
 
         private void MainForm_Load(object sender, EventArgs e)
@@ -135,7 +151,7 @@ namespace EQEmu_Patcher
                 // btnStart.Enabled = false; // this is a cached value
                btnCheck.BackColor = Color.Red;
             } else
-            {
+            {                
                 btnStart.Enabled = true;
                 if ( IniLibrary.instance.AutoPlay.ToLower() == "true") PlayGame();
             }

--- a/EQEmu Patcher/EQEmu Patcher/MainForm.cs
+++ b/EQEmu Patcher/EQEmu Patcher/MainForm.cs
@@ -132,6 +132,7 @@ namespace EQEmu_Patcher
             if (filelist.version != IniLibrary.instance.LastPatchedVersion)
             {
                 isNeedingPatch = true;
+                // btnStart.Enabled = false; // this is a cached value
                btnCheck.BackColor = Color.Red;
             } else
             {                
@@ -460,7 +461,9 @@ namespace EQEmu_Patcher
             isPatching = true;
             btnCheck.Text = "Cancel";
 
-            txtList.Text = "Patching...";
+            LogEvent("Patching..."); // change hides splash logo and shows text list
+            txtList.Refresh();
+
             FileList filelist;
 
             using (var input = File.OpenText("filelist.yml"))
@@ -473,10 +476,16 @@ namespace EQEmu_Patcher
             }
             int totalBytes = 0;
             List<FileEntry> filesToDownload = new List<FileEntry>();
+            int current_count = 0;
             foreach (var entry in filelist.downloads)
             {
                 Application.DoEvents();
+                ++current_count;
                 var path = entry.name.Replace("/", "\\");
+                if (current_count % 1000 == 0 || current_count == 1 || current_count == filelist.downloads.Count)
+                {
+                    LogEvent("Initial check of local files (" + current_count + "/" + filelist.downloads.Count + ")..."); // no need to Refresh buffer
+                }
                 //See if file exists.
                 if (!File.Exists(path))
                 {
@@ -525,6 +534,7 @@ namespace EQEmu_Patcher
 
             if (filesToDownload.Count == 0)
             {
+                btnStart.Enabled = true;
                 LogEvent("Up to date with patch "+filelist.version+".");
                 progressBar.Maximum = progressBar.Value = 1;
                 IniLibrary.instance.LastPatchedVersion = filelist.version;
@@ -552,6 +562,7 @@ namespace EQEmu_Patcher
                 }
             }
             progressBar.Value = progressBar.Maximum;
+            btnStart.Enabled = true;
             LogEvent("Complete! Press Play to begin.");
             IniLibrary.instance.LastPatchedVersion = filelist.version;
             IniLibrary.Save();


### PR DESCRIPTION
1. If eqgame.exe is NOT detected, it will prompt a warning to run the program from a new, empty folder.
2. Fixes the download into system32 bug by setting cwd to the exe path. This bug happens if you e.g. run the patcher from Windows search